### PR TITLE
Can't use MAT_REUSE_MATRIX in tandem with MatConvert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ tinyasm/__pycache__/
 *.pvtu
 *.so
 *.pyc
+/.clangd/
+/compile_commands.json

--- a/tests/test_star_pc.py
+++ b/tests/test_star_pc.py
@@ -1,6 +1,8 @@
 import pytest
 from firedrake import *
+from firedrake.petsc import PETSc
 
+PETSc.Sys.pushErrorHandler("mpiabort")
 
 @pytest.fixture(params=["scalar", "vector", "mixed"])
 def problem_type(request):
@@ -30,7 +32,7 @@ def test_star_equivalence(problem_type, backend):
         nsp = None
 
         star_params = {"mat_type": "aij",
-                       "snes_type": "ksponly",
+                       "snes_type": "newtonls",
                        "ksp_type": "richardson",
                        "pc_type": "mg",
                        "pc_mg_type": "multiplicative",
@@ -43,7 +45,7 @@ def test_star_equivalence(problem_type, backend):
                        "mg_levels_pc_star_construct_dim": 0}
 
         comp_params = {"mat_type": "aij",
-                       "snes_type": "ksponly",
+                       "snes_type": "newtonls",
                        "ksp_type": "richardson",
                        "pc_type": "mg",
                        "pc_mg_type": "multiplicative",

--- a/tinyasm/tinyasm.cpp
+++ b/tinyasm/tinyasm.cpp
@@ -33,7 +33,9 @@ class BlockJacobi {
         vector<PetscScalar> localb;
         vector<PetscScalar> localx;
         PetscSF sf;
+        Mat *localmats_aij;
         Mat *localmats;
+
         vector<IS> dofis;
         vector<PetscInt> piv;
         vector<PetscScalar> fwork;
@@ -55,9 +57,12 @@ class BlockJacobi {
                 piv = vector<PetscInt>(biggestBlock, 0.);
                 iota(piv.begin(), piv.end(), 1);
                 fwork = vector<PetscScalar>(biggestBlock, 0.);
-                localmats = NULL;
+                localmats_aij = NULL;
                 dofis = vector<IS>(numBlocks);
+                auto ierr = PetscMalloc1(numBlocks, &localmats);CHKERRV(ierr);
                 for(int p=0; p<numBlocks; p++) {
+                    auto ndof = dofsPerBlock[p].size();
+                    localmats[p] = NULL;
                     ISCreateGeneral(MPI_COMM_SELF, globalDofsPerBlock[p].size(), globalDofsPerBlock[p].data(), PETSC_USE_POINTER, dofis.data() + p);
                 }
             }
@@ -67,19 +72,28 @@ class BlockJacobi {
             for(int p=0; p<numBlocks; p++) {
                 ISDestroy(&dofis[p]);
             }
-            if(localmats)
-                MatDestroySubMatrices(numBlocks, &localmats);
+            if(localmats_aij) {
+                PetscErrorCode ierr;
+                ierr = MatDestroySubMatrices(numBlocks, &localmats_aij);CHKERRV(ierr);
+            }
+            if (localmats) {
+                PetscErrorCode ierr;
+                for (int p=0; p<numBlocks; p++) {
+                    ierr = MatDestroy(&localmats[p]);CHKERRV(ierr);
+                }
+                ierr = PetscFree(localmats);CHKERRV(ierr);
+            }
             PetscSFDestroy(&sf);
         }
 
         PetscInt updateValuesPerBlock(Mat P) {
             PetscInt ierr, dof;
             int numBlocks = dofsPerBlock.size();
-            ierr = MatCreateSubMatrices(P, numBlocks, dofis.data(), dofis.data(), localmats ? MAT_REUSE_MATRIX : MAT_INITIAL_MATRIX, &localmats);CHKERRQ(ierr);
+            ierr = MatCreateSubMatrices(P, numBlocks, dofis.data(), dofis.data(), localmats_aij ? MAT_REUSE_MATRIX : MAT_INITIAL_MATRIX, &localmats_aij);CHKERRQ(ierr);
             PetscInt info;
             PetscScalar *vv;
             for(int p=0; p<numBlocks; p++) {
-                ierr = MatConvert(localmats[p], MATDENSE, MAT_INPLACE_MATRIX,&(localmats[p]));CHKERRQ(ierr);
+                ierr = MatConvert(localmats_aij[p], MATDENSE, localmats[p] ? MAT_REUSE_MATRIX : MAT_INITIAL_MATRIX,&localmats[p]);CHKERRQ(ierr);
                 PetscInt dof = dofsPerBlock[p].size();
                 ierr = MatDenseGetArrayWrite(localmats[p],&vv);CHKERRQ(ierr);
                 mymatinvert(&dof, vv, piv.data(), &info, fwork.data());
@@ -91,7 +105,7 @@ class BlockJacobi {
                 for(int p=0; p<numBlocks; p++) {
                     cout << "Mat " << p << endl;
                     PetscInt dof = dofsPerBlock[p].size();
-                    ierr = MatDenseGetArrayRead(localmats[p],&vvv);
+                    ierr = MatDenseGetArrayRead(localmats[p],&vvv);CHKERRQ(ierr);
                     for(int i=0; i<dof; i++){
                         for(int j=0; j<dof; j++){
                             cout << vvv[i*dof+j] << " ";


### PR DESCRIPTION
Instead create a separate copy of dense matrices that we use.

This showed up when using TinyASM for nonlinear problems.