### PR TITLE
Recent PETSc commit has renamed PetscStackCallBLAS to PetscCallBLAS

### DIFF
--- a/tinyasm/matinvert.cpp
+++ b/tinyasm/matinvert.cpp
@@ -8,16 +8,16 @@
 using namespace std;
 
 PetscErrorCode mymatinvert(PetscInt* n, PetscScalar* mat, PetscInt* piv, PetscInt* info, PetscScalar* work) {
-    //PetscStackCallBLAS("LAPACKgetrf",LAPACKgetrf_(&dof,&dof,&matValuesPerBlock[p][0],&dof,&piv[0],&info));
-    //PetscStackCallBLAS("LAPACKgetri",LAPACKgetri_(&dof,&matValuesPerBlock[p][0], &dof, &piv[0],&fwork[0],&dof,&info));
+    //PetscCallBLAS("LAPACKgetrf",LAPACKgetrf_(&dof,&dof,&matValuesPerBlock[p][0],&dof,&piv[0],&info));
+    //PetscCallBLAS("LAPACKgetri",LAPACKgetri_(&dof,&matValuesPerBlock[p][0], &dof, &piv[0],&fwork[0],&dof,&info));
 	//dgetrf(n,n,mat,n,piv,info);
 	//dgetri(n,mat, n, piv,work,n,info);
 
 	//LAPACKE_mkl_dgetrfnpi(LAPACK_COL_MAJOR,*n,*n,*n,mat,*n);
 	//LAPACKE_dgetrf(LAPACK_COL_MAJOR,*n,*n,mat,*n, piv);
     //LAPACKE_dgetri(LAPACK_COL_MAJOR, *n,mat, *n, piv);
-    PetscStackCallBLAS("LAPACKgetrf",LAPACKgetrf_(n,n,mat,n,piv,info));
-    PetscStackCallBLAS("LAPACKgetri",LAPACKgetri_(n,mat, n, piv,work,n,info));
+    PetscCallBLAS("LAPACKgetrf",LAPACKgetrf_(n,n,mat,n,piv,info));
+    PetscCallBLAS("LAPACKgetri",LAPACKgetri_(n,mat, n, piv,work,n,info));
 	return 0;
 }
 

--- a/tinyasm/tinyasm.cpp
+++ b/tinyasm/tinyasm.cpp
@@ -144,7 +144,7 @@ class BlockJacobi {
                         for(int j=0; j<dof; j++)
                             x[dofmap[i]] += matvalues[i*dof + j] * workb[j];
                 else {
-                    PetscStackCallBLAS("BLASgemv",BLASgemv_("N", &dof, &dof, &dOne, matvalues, &dof, workb.data(), &one, &dZero, worka.data(), &one));
+                    PetscCallBLAS("BLASgemv",BLASgemv_("N", &dof, &dof, &dOne, matvalues, &dof, workb.data(), &one, &dZero, worka.data(), &one));
                     for(int i=0; i<dof; i++)
                         x[dofmap[i]] += worka[i];
                 }


### PR DESCRIPTION
This commit https://github.com/petsc/petsc/commit/792fecdfe9134cce4d631112660ddd34f063bc17 from 5 days ago has renamed `PetscStackCallBLAS` to `PetscCallBLAS`.

* I tested this change on my local installation.
* Before merging, the firedrake's PETSc fork should be updated to current main branch (cc @ksagiyam)
* Merging this will prevent future failure on my [FEM on Colab](https://fem-on-colab.github.io/) pipeline (which has a PETSc build during the first day of the month, and a firedrake build every saturday)
